### PR TITLE
Add cross build to Scala 2.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val `akka-locality` = project
     version := "1.0.0",
     startYear := Some(2019),
     scalaVersion := "2.12.6",
+    crossScalaVersions := Seq("2.12.6", "2.12.10", "2.13.01"),
     scalacOptions ++= Seq(
       "-unchecked",
       "-deprecation",
@@ -29,7 +30,7 @@ lazy val `akka-locality` = project
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % Test,
       "org.iq80.leveldb" % "leveldb" % "0.12" % "optional;provided;multi-jvm;test",
       "commons-io" % "commons-io" % "2.6" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.5" % Test
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test
     ),
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
   )


### PR DESCRIPTION
@manuelbernhardt Nice project! I was curious how you implemented the locality. Clever!

Whilst reading the code, I wondered if it would cross compile, and it does! I also saw a `compareAndSet` which doesn't check the return value and recurse on failure, which triggered my spidey sense, but in this case it is fine. It seems just using `set` is also, given there is no correct winner in the race, and the work is already done to create the new routees. I hope you don't mind I added a comment. Anyway, if you think any of this is useful, feel free to merge. If not, no problem either.

Summary:
- Added cross build to 2.13.1 and latest 2.12.x
- Bumped version of ScalaTest to 2.13.x compatible version
- Removed some name shadowing and some minor simplification/explanation in the ShardLocationAwareRouter